### PR TITLE
Hilach/dropout

### DIFF
--- a/vit_pytorch/vit_pytorch.py
+++ b/vit_pytorch/vit_pytorch.py
@@ -19,27 +19,27 @@ class PreNorm(nn.Module):
         return self.fn(self.norm(x), **kwargs)
 
 class FeedForward(nn.Module):
-    def __init__(self, dim, hidden_dim, p=0):
+    def __init__(self, dim, hidden_dim, dropout=0):
         super().__init__()
         self.net = nn.Sequential(
             nn.Linear(dim, hidden_dim),
             nn.GELU(),
-            nn.Dropout(p),
+            nn.Dropout(dropout),
             nn.Linear(hidden_dim, dim),
-            nn.Dropout(p)
+            nn.Dropout(dropout)
         )
     def forward(self, x):
         return self.net(x)
 
 class Attention(nn.Module):
-    def __init__(self, dim, heads = 8, p=0):
+    def __init__(self, dim, heads = 8, dropout=0):
         super().__init__()
         self.heads = heads
         self.scale = dim ** -0.5
 
         self.to_qkv = nn.Linear(dim, dim * 3, bias = False)
         self.to_out = nn.Linear(dim, dim)
-        self.dropout = nn.Dropout(p)
+        self.dropout = nn.Dropout(dropout)
     def forward(self, x, mask = None):
         b, n, _, h = *x.shape, self.heads
         qkv = self.to_qkv(x)
@@ -63,13 +63,13 @@ class Attention(nn.Module):
         return out
 
 class Transformer(nn.Module):
-    def __init__(self, dim, depth, heads, mlp_dim):
+    def __init__(self, dim, depth, heads, mlp_dim, attn_dropout, ff_dropout):
         super().__init__()
         self.layers = nn.ModuleList([])
         for _ in range(depth):
             self.layers.append(nn.ModuleList([
-                Residual(PreNorm(dim, Attention(dim, heads = heads))),
-                Residual(PreNorm(dim, FeedForward(dim, mlp_dim)))
+                Residual(PreNorm(dim, Attention(dim, heads = heads, dropout=attn_dropout))),
+                Residual(PreNorm(dim, FeedForward(dim, mlp_dim, dropout=ff_dropout)))
             ]))
     def forward(self, x, mask = None):
         for attn, ff in self.layers:
@@ -78,7 +78,7 @@ class Transformer(nn.Module):
         return x
 
 class ViT(nn.Module):
-    def __init__(self, *, image_size, patch_size, num_classes, dim, depth, heads, mlp_dim, channels = 3, p=0):
+    def __init__(self, *, image_size, patch_size, num_classes, dim, depth, heads, mlp_dim, channels = 3, attn_dropout = 0., ff_dropout = 0.):
         super().__init__()
         assert image_size % patch_size == 0, 'image dimensions must be divisible by the patch size'
         num_patches = (image_size // patch_size) ** 2
@@ -87,20 +87,20 @@ class ViT(nn.Module):
         self.patch_size = patch_size
 
         self.pos_embedding = nn.Parameter(torch.randn(1, num_patches + 1, dim))
-        self.pos_embedding_dropout = nn.Dropout(p)
+        self.pos_embedding_dropout = nn.Dropout(ff_dropout)
         self.patch_to_embedding = nn.Linear(patch_dim, dim)
         self.cls_token = nn.Parameter(torch.randn(1, 1, dim))
-        self.transformer = Transformer(dim, depth, heads, mlp_dim)
+        self.transformer = Transformer(dim, depth, heads, mlp_dim, attn_dropout, ff_dropout)
 
         self.to_cls_token = nn.Identity()
 
         self.mlp_head = nn.Sequential(
             nn.LayerNorm(dim),
             nn.Linear(dim, mlp_dim),
-            nn.Dropout(p),
+            nn.Dropout(ff_dropout),
             nn.GELU(),
             nn.Linear(mlp_dim, num_classes),
-            nn.Dropout(p)
+            nn.Dropout(ff_dropout)
         )
 
     def forward(self, img, mask = None):

--- a/vit_pytorch/vit_pytorch.py
+++ b/vit_pytorch/vit_pytorch.py
@@ -68,7 +68,7 @@ class Transformer(nn.Module):
         self.layers = nn.ModuleList([])
         for _ in range(depth):
             self.layers.append(nn.ModuleList([
-                Residual(PreNorm(dim, Attention(dim, heads=heads, dropout = attn_dropout))),
+                Residual(PreNorm(dim, Attention(dim, heads = heads, dropout = attn_dropout))),
                 Residual(PreNorm(dim, FeedForward(dim, mlp_dim, dropout = ff_dropout)))
             ]))
     def forward(self, x, mask = None):

--- a/vit_pytorch/vit_pytorch.py
+++ b/vit_pytorch/vit_pytorch.py
@@ -19,7 +19,7 @@ class PreNorm(nn.Module):
         return self.fn(self.norm(x), **kwargs)
 
 class FeedForward(nn.Module):
-    def __init__(self, dim, hidden_dim, dropout=0):
+    def __init__(self, dim, hidden_dim, dropout = 0.):
         super().__init__()
         self.net = nn.Sequential(
             nn.Linear(dim, hidden_dim),
@@ -32,7 +32,7 @@ class FeedForward(nn.Module):
         return self.net(x)
 
 class Attention(nn.Module):
-    def __init__(self, dim, heads = 8, dropout=0):
+    def __init__(self, dim, heads = 8, dropout = 0.):
         super().__init__()
         self.heads = heads
         self.scale = dim ** -0.5
@@ -68,8 +68,8 @@ class Transformer(nn.Module):
         self.layers = nn.ModuleList([])
         for _ in range(depth):
             self.layers.append(nn.ModuleList([
-                Residual(PreNorm(dim, Attention(dim, heads = heads, dropout=attn_dropout))),
-                Residual(PreNorm(dim, FeedForward(dim, mlp_dim, dropout=ff_dropout)))
+                Residual(PreNorm(dim, Attention(dim, heads=heads, dropout = attn_dropout))),
+                Residual(PreNorm(dim, FeedForward(dim, mlp_dim, dropout = ff_dropout)))
             ]))
     def forward(self, x, mask = None):
         for attn, ff in self.layers:


### PR DESCRIPTION
Thanks for the useful resource @lucidrains!
I saw this part from the paper:
 Dropout, when used, is applied after every dense layer except for the the qkv-projections and directly after adding positional- to patch embeddings.
So 3 things regarding the dropouts you added:
1. I think there's a dropout missing right after adding the positional to the embedding.
2. I don't see why there should be a dropout after the dot product in the attention- line 57 (it's not a dense layer and it's not mentioned in the above description).
3. considering they refer to the qkv-projections as dense layers, I think they mean that all linear layers are dense layers, so I added dropouts after each linear layer.

Kindly let me know if you have any comments/ disagreements.
