### PR TITLE
Fix alpha coefficient multiplication in the loss

### DIFF
--- a/vit_pytorch/distill.py
+++ b/vit_pytorch/distill.py
@@ -150,4 +150,4 @@ class DistillWrapper(nn.Module):
             teacher_labels = teacher_logits.argmax(dim = -1)
             distill_loss = F.cross_entropy(student_logits, teacher_labels)
 
-        return loss * alpha + distill_loss * (1 - alpha)
+        return loss * (1 - alpha) + distill_loss * alpha


### PR DESCRIPTION
I think the way the alpha coefficient is multiplied in the loss was not correct for Distillable ViT. 

Of course for the special case of `alpha = 0.5`, it doesn't matter but for other values this will diverge from how it is done in the paper.

The formula can be seen on page 6 of this paper: https://arxiv.org/pdf/2012.12877.pdf