### PR TITLE
display random images when previewing in cats_and_dogs.ipynb

### DIFF
--- a/examples/cats_and_dogs.ipynb
+++ b/examples/cats_and_dogs.ipynb
@@ -276,12 +276,12 @@
     }
    ],
    "source": [
-    "random_idx = np.random.randint(1, len(train_list), size=9)\n",
+    "random_idx = np.random.randint(0, len(train_list), size=9)\n",
     "fig, axes = plt.subplots(3, 3, figsize=(16, 12))\n",
     "\n",
     "for idx, ax in enumerate(axes.ravel()):\n",
-    "    img = Image.open(train_list[idx])\n",
-    "    ax.set_title(labels[idx])\n",
+    "    img = Image.open(train_list[random_idx[idx]])\n",
+    "    ax.set_title(labels[random_idx[idx]])\n",
     "    ax.imshow(img)\n"
    ]
   },


### PR DESCRIPTION
Random indices were generated in the variable `random_idx`, but it was not used and the same 1-9 images were plotted. This commit fixes that and shows the images from the random indices generated.