### PR TITLE
Update distill.py to include device agnostic code for `distill_mlp` head and `distillation_token`

### DIFF
--- a/vit_pytorch/distill.py
+++ b/vit_pytorch/distill.py
@@ -116,6 +116,7 @@ class DistillWrapper(Module):
         super().__init__()
         assert (isinstance(student, (DistillableViT, DistillableT2TViT, DistillableEfficientViT))) , 'student must be a vision transformer'
 
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
         self.teacher = teacher
         self.student = student
 
@@ -125,12 +126,12 @@ class DistillWrapper(Module):
         self.alpha = alpha
         self.hard = hard
 
-        self.distillation_token = nn.Parameter(torch.randn(1, 1, dim))
+        self.distillation_token = nn.Parameter(torch.randn(1, 1, dim,device=device))
 
         self.distill_mlp = nn.Sequential(
             nn.LayerNorm(dim) if mlp_layernorm else nn.Identity(),
             nn.Linear(dim, num_classes)
-        )
+        ).to(device)
 
     def forward(self, img, labels, temperature = None, alpha = None, **kwargs):
 


### PR DESCRIPTION
Since in your code, the `distillation_token` and `distill_mlp` heads are defined in the `DistillWrapper` class, sending the model instance of the `DistillableViT` class to GPU does not send the `distillation_token` and `distill_mlp` head to GPU. Therefore, while training a model using this code, I got a device mismatch error, which made it hard to figure out the source of the error. Finally, the `distillation_token` and `distill_mlp` turned out to be the culprits as they are not defined in the model class but in the `DistillWrapper` class, which is a wrapper of loss function. Therefore, I have suggested the following changes when training a model on GPU: the training code should set the `device="cude" if torch.cuda.is_available() else "cpu"`, or the same can be incorporated into the constructor of the `DistillWrapper` class.