### PR TITLE
Allow to pass mask parameter for temporal transformer in ViVit

### DIFF
--- a/vit_pytorch/vivit.py
+++ b/vit_pytorch/vivit.py
@@ -72,16 +72,17 @@ class Attention(nn.Module):
         q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> b h n d', h = self.heads), qkv)
 
         if self.use_flash_attn:
-            return self.flash_attn(q, k, v, mask=mask)
+            out =  self.flash_attn(q, k, v, mask=mask)
 
-        dots = torch.matmul(q, k.transpose(-1, -2)) * self.scale
+        else:
+            dots = torch.matmul(q, k.transpose(-1, -2)) * self.scale
 
-        if mask is not None:
-            dots = dots.masked_fill(mask.view(B, 1, 1, F) == 0, float('-inf'))
-        attn = self.attend(dots)
-        attn = self.dropout(attn)
+            if mask is not None:
+                dots = dots.masked_fill(mask.view(B, 1, 1, F) == 0, float('-inf'))
+            attn = self.attend(dots)
+            attn = self.dropout(attn)
 
-        out = torch.matmul(attn, v)
+            out = torch.matmul(attn, v)
         out = rearrange(out, 'b h n d -> b n (h d)')
         return self.to_out(out)
 


### PR DESCRIPTION
A small QoL update for ViViT, to more efficiently train ViViT videos can be in different length but right now there's no way to "pad video" to allow for batched processing of different length videos.

This feature allows to pad videos to certain length which allow the temporal transformer to ignore padded frames when using batch sizes > 1