### PR TITLE
Missing and inconsistent einsum operations

### DIFF
--- a/vit_pytorch/lejepa.py
+++ b/vit_pytorch/lejepa.py
@@ -2,10 +2,9 @@ import random
 from functools import wraps
 
 import torch
-from torch import nn
+from torch import nn, einsum
 from torch.nn import Module
 import torch.nn.functional as F
-from torch import einsum
 
 from torchvision import transforms as T
 from einops import rearrange

--- a/vit_pytorch/lejepa.py
+++ b/vit_pytorch/lejepa.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 from torch.nn import Module
 import torch.nn.functional as F
+from torch import einsum
 
 from torchvision import transforms as T
 from einops import rearrange
@@ -64,7 +65,7 @@ def sigreg_loss(
 
     # empirical CF
 
-    x_t = torch.einsum('... d, m d -> ... m', x, rand_projs)
+    x_t = einsum('... d, m d -> ... m', x, rand_projs)
     x_t = rearrange(x_t, '... m -> (...) m')
 
     x_t = rearrange(x_t, 'n m -> n m 1') * t

--- a/vit_pytorch/look_vit.py
+++ b/vit_pytorch/look_vit.py
@@ -1,9 +1,9 @@
 import torch
-from torch import nn
+from torch import nn, einsum
 import torch.nn.functional as F
 from torch.nn import Module, ModuleList
 
-from einops import einsum, rearrange, repeat, reduce
+from einops import rearrange, repeat, reduce
 from einops.layers.torch import Rearrange
 
 # helpers

--- a/vit_pytorch/simple_flash_attn_vit.py
+++ b/vit_pytorch/simple_flash_attn_vit.py
@@ -4,6 +4,7 @@ from packaging import version
 import torch
 import torch.nn.functional as F
 from torch import nn
+from torch import einsum
 
 from einops import rearrange
 from einops.layers.torch import Rearrange

--- a/vit_pytorch/simple_flash_attn_vit.py
+++ b/vit_pytorch/simple_flash_attn_vit.py
@@ -175,3 +175,19 @@ class SimpleViT(nn.Module):
 
         x = self.to_latent(x)
         return self.linear_head(x)
+
+if __name__ == "__main__":
+    vit = SimpleViT(
+        image_size = 256,
+        patch_size = 32,
+        num_classes = 1000,
+        dim = 1024,
+        depth = 7,
+        heads = 16,
+        mlp_dim = 2048
+    )
+
+    images = torch.randn(2, 3, 256, 256)
+
+    predictions = vit(images)
+    assert predictions.shape == (2, 1000)

--- a/vit_pytorch/simple_flash_attn_vit.py
+++ b/vit_pytorch/simple_flash_attn_vit.py
@@ -3,8 +3,7 @@ from packaging import version
 
 import torch
 import torch.nn.functional as F
-from torch import nn
-from torch import einsum
+from torch import nn, einsum
 
 from einops import rearrange
 from einops.layers.torch import Rearrange

--- a/vit_pytorch/simple_flash_attn_vit_3d.py
+++ b/vit_pytorch/simple_flash_attn_vit_3d.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 from torch.nn import Module, ModuleList
+from torch import einsum
 
 from einops import rearrange
 from einops.layers.torch import Rearrange

--- a/vit_pytorch/simple_flash_attn_vit_3d.py
+++ b/vit_pytorch/simple_flash_attn_vit_3d.py
@@ -170,3 +170,21 @@ class SimpleViT(Module):
 
         x = self.to_latent(x)
         return self.linear_head(x)
+
+if __name__ == "__main__":
+    vit = SimpleViT(
+        image_size = 128,
+        image_patch_size = 16,
+        frames = 8,
+        frame_patch_size = 2,
+        num_classes = 1000,
+        dim = 256,
+        depth = 6,
+        heads = 8,
+        mlp_dim = 512,
+    )
+
+    videos = torch.randn(2, 3, 8, 128, 128)
+
+    predictions = vit(videos)
+    assert predictions.shape == (2, 1000)

--- a/vit_pytorch/simple_flash_attn_vit_3d.py
+++ b/vit_pytorch/simple_flash_attn_vit_3d.py
@@ -2,10 +2,9 @@ from packaging import version
 from collections import namedtuple
 
 import torch
-from torch import nn
+from torch import nn, einsum
 import torch.nn.functional as F
 from torch.nn import Module, ModuleList
-from torch import einsum
 
 from einops import rearrange
 from einops.layers.torch import Rearrange

--- a/vit_pytorch/simple_vit_with_hyper_connections.py
+++ b/vit_pytorch/simple_vit_with_hyper_connections.py
@@ -4,9 +4,8 @@ https://arxiv.org/abs/2409.19606
 """
 
 import torch
-from torch import nn, tensor
+from torch import nn, tensor, einsum
 from torch.nn import Module, ModuleList
-from torch import einsum
 
 from einops import rearrange, repeat, reduce, pack, unpack
 from einops.layers.torch import Rearrange

--- a/vit_pytorch/simple_vit_with_hyper_connections.py
+++ b/vit_pytorch/simple_vit_with_hyper_connections.py
@@ -6,8 +6,9 @@ https://arxiv.org/abs/2409.19606
 import torch
 from torch import nn, tensor
 from torch.nn import Module, ModuleList
+from torch import einsum
 
-from einops import rearrange, repeat, reduce, einsum, pack, unpack
+from einops import rearrange, repeat, reduce, pack, unpack
 from einops.layers.torch import Rearrange
 
 # b - batch, h - heads, n - sequence, e - expansion rate / residual streams, d - feature dimension

--- a/vit_pytorch/vit_with_decorr.py
+++ b/vit_pytorch/vit_with_decorr.py
@@ -2,11 +2,11 @@
 # but instead of their decorr module updated with SGD, remove all projections and just return a decorrelation auxiliary loss
 
 import torch
-from torch import nn, stack, tensor
+from torch import nn, stack, tensor, einsum
 import torch.nn.functional as F
 from torch.nn import Module, ModuleList
 
-from einops import rearrange, repeat, reduce, einsum, pack, unpack
+from einops import rearrange, repeat, reduce, pack, unpack
 from einops.layers.torch import Rearrange
 
 # helpers


### PR DESCRIPTION
Following:

- Fixes missing einsum operations
- Makes them consistently be imported from `torch` which is faster and not `einops` .
- Adds smoke tests to `simple_flash_attn_vit_3d` and `simple_flash_attn_vit`.
